### PR TITLE
[OSQP-Eigen] use the correct git tag for ubuntu16.04

### DIFF
--- a/3rdparty/osqp-eigen/CMakeLists.txt
+++ b/3rdparty/osqp-eigen/CMakeLists.txt
@@ -6,6 +6,22 @@ find_package(osqp REQUIRED)
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
+
+
+find_program(LSB_RELEASE_EXEC lsb_release)
+execute_process(COMMAND ${LSB_RELEASE_EXEC} -c
+    OUTPUT_VARIABLE LSB_RELEASE_CODENAME
+)
+
+string(REPLACE "\t" ";" LSB_RELEASE_CODENAME_LIST ${LSB_RELEASE_CODENAME})
+list(GET LSB_RELEASE_CODENAME_LIST 1 CODENAME)
+
+if(${CODENAME} MATCHES "xenial")
+  set(GIT_TAG 338447d)
+else()
+  set(GIT_TAG v0.6.2)
+endif()
+
 execute_process(COMMAND
   git config --global http.sslVerify false)
 ## System dependencies are found with CMake's conventions
@@ -13,7 +29,7 @@ execute_process(COMMAND
 ExternalProject_Add(
   osqp-eigen
   GIT_REPOSITORY https://github.com/robotology/osqp-eigen
-  GIT_TAG v0.6.2
+  GIT_TAG ${GIT_TAG}
   CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
   INSTALL_COMMAND echo "install"
   DEPEND osqp


### PR DESCRIPTION
### What is this

The tag of v0.6.2 is not suitable for Ubuntu16.04 becuase of Eigen library.
Please refre to https://github.com/JSKAerialRobot/aerial_robot_3rdparty/actions/runs/6521815766/job/17710763240 for more detail