### PR TITLE
[mujoco] do not convert mujoco model in aarch64

### DIFF
--- a/mujoco_ros_control/cmake/model_convert.cmake
+++ b/mujoco_ros_control/cmake/model_convert.cmake
@@ -8,8 +8,17 @@ macro(mujoco_model_convert _PROJECT_SOURCE_DIR _YAML_FILE)
   string(REPLACE "\t" ";" LSB_RELEASE_CODENAME_LIST ${LSB_RELEASE_CODENAME})
   list(GET LSB_RELEASE_CODENAME_LIST 1 CODENAME)
 
+  find_program(UNAME_EXEC uname)
+  execute_process(COMMAND ${UNAME_EXEC} -m
+    OUTPUT_VARIABLE UNAME_OUTPUT
+    )
+
   if(${CODENAME} MATCHES "xenial")
     MESSAGE(WARNING "Do not convert mujoco model in ${CODENAME}, because of old version of blender")
+
+  elseif(${UNAME_OUTPUT} MATCHES "aarch64")
+    MESSAGE(WARNING "Do not convert mujoco model in ${UNAME_OUTPUT}")
+
   else()
 
     add_custom_command(OUTPUT ${_PROJECT_SOURCE_DIR}/mujoco


### PR DESCRIPTION
### what is this
Do not convert mujoco model in aarch64.

### details
In aarch64, blender seems not to be worked and mujoco model generation fail. And, all members are using intel cpu for simulation. 
In this PR, skip the mujco model generation process in aarch64.
```
$ blender -v
blender: symbol lookup error: /lib/aarch64-linux-gnu/libSDL2-2.0.so.0: undefined symbol: wl_egl_window_destroy
```