### PR TITLE
[OSQP-Eigen] build under C++17

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -22,13 +22,24 @@ source /opt/ros/${ROS_DISTRO}/setup.bash
 
 # Setup for rosdep
 sudo rosdep init
+
 # use snapshot of rosdep list
-    # https://github.com/ros/rosdistro/pull/31570#issuecomment-1000497517
+# https://github.com/ros/rosdistro/pull/31570#issuecomment-1000497517
 if [[ "$ROS_DISTRO" = "kinetic" ]]; then
     sudo rm /etc/ros/rosdep/sources.list.d/20-default.list
     sudo wget https://gist.githubusercontent.com/cottsay/b27a46e53b8f7453bf9ff637d32ea283/raw/476b3714bb90cfbc6b8b9d068162fc6408fa7f76/30-xenial.list -O /etc/ros/rosdep/sources.list.d/30-xenial.list
 fi
 rosdep update --include-eol-distros
+
+if [[ "$ROS_DISTRO" = "kinetic" ]]; then
+    # to use c++17
+    sudo apt-get install -y software-properties-common
+    sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+    sudo apt update
+    sudo apt install -y g++-7
+    export CXX='g++-7'
+    export CC='gcc-7'
+fi
 
 # Install source code
 mkdir -p ~/catkin_ws/src

--- a/3rdparty/osqp-eigen/CMakeLists.txt
+++ b/3rdparty/osqp-eigen/CMakeLists.txt
@@ -7,7 +7,6 @@ find_package(osqp REQUIRED)
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
 
-
 find_program(LSB_RELEASE_EXEC lsb_release)
 execute_process(COMMAND ${LSB_RELEASE_EXEC} -c
     OUTPUT_VARIABLE LSB_RELEASE_CODENAME
@@ -18,8 +17,10 @@ list(GET LSB_RELEASE_CODENAME_LIST 1 CODENAME)
 
 if(${CODENAME} MATCHES "xenial")
   set(GIT_TAG 338447d)
+   set(PATCH "s/set\(CMAKE_CXX_STANDARD\ 14\)/add_compile_options\(-std=c++17\)/g")
 else()
   set(GIT_TAG v0.6.2)
+  set(PATCH "s/cxx_std_14/cxx_std_17/g")
 endif()
 
 execute_process(COMMAND
@@ -30,6 +31,8 @@ ExternalProject_Add(
   osqp-eigen
   GIT_REPOSITORY https://github.com/robotology/osqp-eigen
   GIT_TAG ${GIT_TAG}
+  PATCH_COMMAND
+    COMMAND sed -i -e ${PATCH} CMakeLists.txt
   CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
   INSTALL_COMMAND echo "install"
   DEPEND osqp


### PR DESCRIPTION
### What is this

Since the need of C++ version later than C++17 in depending packages.
The designated version of C++14 in cmake can make the build error.
Therefore, we add a patch to replace the C++ version.

