### PR TITLE
[CI][Github Action] stop the support of kinetic ros-distribution

### DIFF
--- a/.github/workflows/ros_test.yml
+++ b/.github/workflows/ros_test.yml
@@ -8,8 +8,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - ROS_DISTRO : kinetic
-            DOCKER_IMAGE : ubuntu:xenial
           - ROS_DISTRO : melodic
             DOCKER_IMAGE : ubuntu:bionic
           - ROS_DISTRO : noetic


### PR DESCRIPTION
### What is this 

We have removed the kinetic ros-distribution from the list of  Github Action workflows, becuase it is too legacy.